### PR TITLE
fix: deprecated single_blank_line_before_namespace

### DIFF
--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -239,7 +239,6 @@ final class Php81 implements RuleSetInterface
             'simple_to_complex_string_variable' => true,
             'simplified_null_return' => false,
             'single_blank_line_at_eof' => true,
-            'single_blank_line_before_namespace' => true,
             'single_class_element_per_statement' => true,
             'single_import_per_statement' => true,
             'single_line_comment_style' => true,

--- a/src/RuleSet/Php82.php
+++ b/src/RuleSet/Php82.php
@@ -239,7 +239,6 @@ final class Php82 implements RuleSetInterface
             'simple_to_complex_string_variable' => true,
             'simplified_null_return' => false,
             'single_blank_line_at_eof' => true,
-            'single_blank_line_before_namespace' => true,
             'single_class_element_per_statement' => true,
             'single_import_per_statement' => true,
             'single_line_comment_style' => true,


### PR DESCRIPTION
[Deprecated](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/9b1ae68f1ad0bd9cb09357cf046eb49933d1859e/doc/rules/namespace_notation/single_blank_line_before_namespace.rst#this-rule-is-deprecated-and-will-be-removed-on-next-major-version).

see https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/commit/24f863c6a3958273d1dea3902b7781b9d9aca264