### PR TITLE
fix: lock PHP CS Fixer to v3.45

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "stickee's PHP CS Fixer config",
     "require": {
         "php": "^8.1",
-        "friendsofphp/php-cs-fixer": "^3.13",
+        "friendsofphp/php-cs-fixer": "3.45",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "license": "MIT",


### PR DESCRIPTION
v3.46 is producing the wrong changes for FQCN
so I am locking the upper range to v3.45 until FQCN work is finished