### PR TITLE
chore(deps): unlock php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "stickee's PHP CS Fixer config",
     "require": {
         "php": "^8.3",
-        "friendsofphp/php-cs-fixer": "3.53.0",
+        "friendsofphp/php-cs-fixer": "^3.62.0",
         "adamwojs/php-cs-fixer-phpdoc-force-fqcn": "^2.0"
     },
     "license": "MIT",


### PR DESCRIPTION
This PR unlocks the version constraint of PHP CS Fixer.

Previously it was locked because of a bug but that has been fixed and now we can follow the latest releases again.

https://github.com/stickeeuk/php-cs-fixer-config/pull/43 can be closed after this goes in.