### PR TITLE
feat: null type always last in docblock '@return'

### DIFF
--- a/src/RuleSet/StickeeBaseline.php
+++ b/src/RuleSet/StickeeBaseline.php
@@ -178,7 +178,7 @@ abstract class StickeeBaseline implements RuleSetInterface
             'phpdoc_to_comment' => false,
             'phpdoc_trim_consecutive_blank_line_separation' => true,
             'phpdoc_trim' => true,
-            'phpdoc_types_order' => true,
+            'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
             'phpdoc_types' => true,
             'phpdoc_var_annotation_correct_order' => true,
             'phpdoc_var_without_name' => true,


### PR DESCRIPTION
This follows the config that the [`@Symfony` rule set](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/phpdoc/phpdoc_types_order.rst#rule-sets) uses. It is not enforced by any spec so it's just personal preference, and this is a better personal preference than we used to have. Even ChatGPT agrees.

> The preferred format of `@return \Stickee\Affiliates\Models\Property|null` is based on widely adopted conventions in the PHP community and best practices in documentation standards. However, both formats are technically correct and understood by most modern IDEs and tools that parse PHPDoc.

> Several influential sources and tools support this convention:

>    PHP-FIG (PHP Framework Interoperability Group): While the PSR standards don't specify the order explicitly, they emphasize readability and consistency. Many PSR-compliant projects follow the Type|null format.

>    Popular PHP frameworks: Many popular frameworks like Laravel, Symfony, and others follow the Type|null convention in their documentation.

>    PHPDoc documentation: While not explicitly stating an order, many examples in the PHPDoc documentation use Type|null.

>    Common practice in the community: A large portion of the PHP community and open-source projects follow the Type|null format, making it a de facto standard.

> Ultimately, consistency within a project or organization is the most important factor. Choose one format and apply it uniformly across your codebase.

I would consider bumping the minimum requirements of this config in `stickee/canary` and releasing as a feature to force a version bump so that we can tell devs to upgrade to a newer version of Canary as this will, technically, mean everyone using Canary _should_ run `canary fix` to apply the change.