### PR TITLE
feat: enable parallel processing

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use Stickee\PhpCsFixerConfig;
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->append([
         __DIR__ . '/.php-cs-fixer.dist.php',
-    ])
-;
+    ]);
 
 $overrideRules = [
     'ordered_class_elements' => ['order' => ['use_trait']],
@@ -22,7 +22,8 @@ $config = PhpCsFixerConfig\Factory::fromRuleSet(
 
 $config
     ->setFinder($finder)
-    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache')
-;
+    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
+
+$config->setParallelConfig(ParallelConfigFactory::detect());
 
 return $config;

--- a/dist/.php-cs-fixer.dist.php
+++ b/dist/.php-cs-fixer.dist.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 use Stickee\PhpCsFixerConfig;
 
 $finder = PhpCsFixer\Finder::create()
@@ -11,8 +12,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/tests')
     ->append([
         __DIR__ . '/.php-cs-fixer.dist.php',
-    ])
-;
+    ]);
 
 $overrideRules = [
     'ordered_class_elements' => ['order' => ['use_trait']],
@@ -25,7 +25,8 @@ $config = PhpCsFixerConfig\Factory::fromRuleSet(
 
 $config
     ->setFinder($finder)
-    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache')
-;
+    ->setCacheFile(__DIR__ . '/.php-cs-fixer.cache');
+
+$config->setParallelConfig(ParallelConfigFactory::detect());
 
 return $config;


### PR DESCRIPTION
> You can also fix files in parallel, utilising more CPU cores. You can do this by using config class that implements PhpCsFixer\Runner\Parallel\ParallelConfig\ParallelAwareConfigInterface, and use setParallelConfig() method. Recommended way is to utilise auto-detecting parallel configuration:

```php
<?php

return (new PhpCsFixer\Config())
    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
;
```
> [!WARNING]
> "Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!"

https://cs.symfony.com/doc/usage.html